### PR TITLE
made Recent Posts entries responsive <450px

### DIFF
--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -97,7 +97,7 @@ color:var(--dark);
     /*background-color: var(--primary);*/
     border-radius: var(--border-radius);
     padding: 10px 10px;
-    margin: 0px auto 5px auto;*/
+    margin: 0px auto 5px auto;
 }
   
 .clicked {

--- a/public/assets/css/history.css
+++ b/public/assets/css/history.css
@@ -153,3 +153,16 @@
     border-radius: var(--border-radius);
 }
 
+@media screen and (max-width: 450px) {
+    /* when the screen size is 450px or less */
+    .posts {
+        flex-wrap: wrap;
+        position: relative;
+        /* the contents of each entry under Recent Posts are wrapped... */
+    }
+    .x-button {
+        position: absolute;
+        right: 10px;
+        /* ...but the delete button is kept on the right side of the box */
+    }
+}

--- a/views/history.handlebars
+++ b/views/history.handlebars
@@ -70,11 +70,9 @@
                 </div>
             </nav>
         </div>
-        <div class="media-right">
+        <div class="x-button media-right">
             <button id="delete-post" class="delete"></button>
         </div>
     </article>
     {{/each}}
-</div>
-
 </div>


### PR DESCRIPTION
Made the boxes under Recent Posts stay readable as the screen shrinks down to 300px

Starting at 450px, box contents are wrapped but the x button stays at top right corner